### PR TITLE
remove invalid RSS link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,6 @@
 
 Join the [kubernetes-security-announce] group for security and vulnerability announcements.
 
-You can also subscribe to an RSS feed of the above using [this link][kubernetes-security-announce-rss].
-
 ## Reporting a Vulnerability
 
 Instructions for reporting a vulnerability can be found on the


### PR DESCRIPTION
This link as of now is present in every repo under kubernetes-sigs org. 

RSS for google groups is no longer supported. I was trying to use it after looking at security tab of kubernetes-sigs/cluster-api repo and this link was returning 404.

This commit removes the invalid link.

